### PR TITLE
Feat/yaml inline add notes

### DIFF
--- a/src/pages/_inline_map_components.yaml
+++ b/src/pages/_inline_map_components.yaml
@@ -1,6 +1,8 @@
 blocks:
   - type: "content"
     content:
+      - h1:
+        - str: "Example page with inline maps from a yaml file"
       - p: 
         - str: "An example of an interactive map"
 
@@ -56,7 +58,7 @@ blocks:
   - type: "content"
     content:
       - p: 
-        - str: "... and a static map. Note that the container ID must be unique."
+        - str: "... and below is a static map. Note that the container ID must be unique (in the example below it is maplibremap2)."
 
   - type: "map"
     content:
@@ -71,10 +73,9 @@ blocks:
   - type: "content"
     content:
       - p: 
-        - str: "... and a static map from an image you have composed"
+        - str: "... and a static map from an image you have composed." 
       - p: 
-        - str: "To add static images from a jpg or png file use the syntax below"
-        - str: "you must include the reference name that corresponds to the file path you have listed above"
+        - str: "To add static images from a jpg or png file save the image in the public/img folder and use the syntax below"
       - img:
         - src: "./img/fisk02.jpg"
           alt: "image description"
@@ -85,6 +86,8 @@ blocks:
         - str: "A subsection"
       - p: 
         - str: "You can go into more detail here."
+      - p: 
+        - str: "To start a new paragraph you must insert a new p section as shown here. "
 
   - type: "content"
     content:

--- a/src/pages/full_page_map.mdx
+++ b/src/pages/full_page_map.mdx
@@ -10,7 +10,7 @@ import { default as FullPageMap } from "@components/FullPageMap.astro";
     longitude={-73.9604192}
     zoom={12}
     interactive="true"
-    mapstyle="https://api.maptiler.com/maps/dataviz/style.json?key=WlatIY6MghFCwInJhBkl"
+    mapstyle="./style.json"
     containerstyle="width: 100%; height: 50vh"
   />
 </PageLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,15 @@ import { HOME } from "@consts";
         The <b>pages/inline_maps.mdx</b> page (available at <a
           href="/astro-maplibre-template/inline_maps">/inline_maps</a
         >) demonstrates how to create a page with interactive mapstyle that is
-        embedded directly in the page, interspersed with text and images. The
+        embedded directly in the page, interspersed with text and images.
+      </p>
+      <p>
+        The <b>pages/inline_maps_yaml.mdx</b> page (available at <a
+        href="/astro-maplibre-template/inline_maps_yaml">/inline_maps_yaml</a>)demonstrates 
+        how to create the same page type as above but by using yaml based syntax which 
+        is written and edited in the <b>pages/_inline_map_components.yaml</b> file. 
+      </p>
+      <p>The
         `full_page_map.mdx` page (available at <a
           href="/astro-maplibre-template/full_page_map">/full_page_maps</a
         >) demonstrates how to create a full page map.


### PR DESCRIPTION
Suggested changes/additions to description for the added yaml version of the inline maps page. 

Resolved a style link in the full_page_map.mdx file that was causing merge conflicts with the template as well. 