### PR TITLE
scrollytelling animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,23 @@ As always, be mindful of indentation when editing the YAML file. The YAML parser
 ## Scrollytelling
 Uses a YAML convention to pass arguments to the map object. Steps are defined in `pages/scrollytelling_steps.yaml`, which is invoked in `payes/scrolltelling.mdx`. That's where the initial position and map style should be defined. Otherwise text, images, etc. should be defined in the yaml file. I'd like to continue to add features to the steps, including passing the hidden variable, animation control, and more layer control. This is just a matter of copying the mapbox scrollytelling logic over. 
 
+#### Scrollytelling step options
+
+| **Option**         | **Type**               | **Required** | **Description**                                                                                                    | **Example**                                                   |
+|---------------------|------------------------|--------------|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| `title`            | `string`              | Yes          | The title of the map step.                                                                                         | `"London"`                                                    |
+| `center`           | `[number, number]`    | Yes          | Geographic coordinates `[longitude, latitude]` for the map center.                                                | `[-0.1278, 51.5074]`                                          |
+| `zoom`             | `number`              | Yes          | Zoom level for the map.                                                                                            | `8`                                                           |
+| `pitch`            | `number`              | No           | The tilt angle of the map in degrees (0-60).                                                                       | `30`                                                          |
+| `bearing`          | `number`              | No           | The rotation angle of the map in degrees.                                                                          | `-10`                                                         |
+| `description`      | `string`              | No           | A descriptive text for the map step.                                                                               | `"You can change the position of the overlay div..."`         |
+| `media`            | `string` (URL)        | No           | URL of an image or media to display with the map step.                                                             | `"https://img.atlasobscura.com/OGZXBPY6..."`                  |
+| `position`         | `"left", "right", "centered", "full"` | No           | The position of the overlay div relative to the map.                                                               | `"right"`                                                     |
+| `mapAnimation`     | `"flyTo", "easeTo", "jumpTo"`   | No           | The type of animation used to transition between map steps.                                                        | `"jumpTo"`                                                    |
+| `rotateAnimation`  | `boolean`             | No           | Enables map rotation when the step is active.                                                                      | `true`                                                        |
+| `layers`           | `Array` of objects    | No           | A list of layers to add to the map.                                                                                | See layer object example below.                               |
+
+
 
 ## Full page
 Full page maps are shown in the `full_page_map.mdx` file in `/pages`. This is a simple map that takes the same arguments as the inline map, but is rendered as a full page map. Layers are defined in the `_full_map_map_components.yaml` file in the `/components` directory.

--- a/src/components/Scrollytelling.astro
+++ b/src/components/Scrollytelling.astro
@@ -155,37 +155,19 @@ const layersJson = layers ? JSON.stringify(layers) : undefined;
                         essential: true,
                       });
 
+                      const rotateAnimation =
+                        entry.target.getAttribute(
+                          "data-map-rotate-animation"
+                        ) === "true";
                       
-
-const rotateAnimation =
-  entry.target.getAttribute("data-map-rotate-animation") === "true";
-
-console.log(rotateAnimation);
-
-if (rotateAnimation) {
-  if (!isRotating) {
-    // Start the rotation if it's not already running
-    isRotating = true;
-
-    const rotate = () => {
-      if (isRotating) {
-        map.rotateTo(map.getBearing() + 180, {
-          duration: 30000,
-          easing: (t) => t,
-        });
-      }
-    };
-
-    map.on("moveend", rotate);
-    rotate(); // Trigger the first rotation immediately
-  }
-} else {
-  if (isRotating) {
-    // Stop the rotation when leaving a rotating block
-    isRotating = false;
-    map.off("moveend"); // Remove the `moveend` event listener
-  }
-}
+                      if (rotateAnimation === true) {
+                        map.once("moveend", () => {
+                          map.rotateTo(map.getBearing() + 180, {
+                            duration: 30000,
+                            easing: (t: number) => t,
+                          });
+                        });
+                      } 
                     } else {
                       if (!entry.target.getAttribute("data-persist")) {
                         // Remove the active class from the section

--- a/src/components/Scrollytelling.astro
+++ b/src/components/Scrollytelling.astro
@@ -20,6 +20,8 @@ interface MapStep {
   position?: "left" | "right" | "centered" | "full";
   layers?: LayerGroup[];
   persist?: boolean;
+  mapAnimation?: "flyTo" | "easeTo" | "jumpTo";
+  rotateAnimation?: boolean;
 }
 
 const mapData: MapStep[] = yaml.load(fileContents) as MapStep[];
@@ -37,6 +39,8 @@ export interface Props {
   pitch?: number;
   bearing?: number;
   layers?: LayerGroup[];
+  mapAnimation?: "flyTo" | "easeTo" | "jumpTo";
+  rotateAnimation?: boolean;
 }
 
 const {
@@ -50,6 +54,8 @@ const {
   pitch,
   bearing,
   layers,
+  mapAnimation,
+  rotateAnimation,
 } = Astro.props;
 const layersJson = layers ? JSON.stringify(layers) : undefined;
 ---
@@ -58,7 +64,7 @@ const layersJson = layers ? JSON.stringify(layers) : undefined;
   <!-- Map Container -->
   <div
     id={container}
-    class="maplibre-inline map-container"
+    class="maplibre-scrollytelling map-container"
     style={{ width: "100vw", height: "100vh" }}
   >
     <maplibre-map
@@ -72,6 +78,8 @@ const layersJson = layers ? JSON.stringify(layers) : undefined;
       data-pitch={pitch}
       data-bearing={bearing}
       data-layers={layersJson}
+      data-map-animation={mapAnimation}
+      data-map-rotate-animation={rotateAnimation}
     >
       <link
         rel="stylesheet"
@@ -85,6 +93,7 @@ const layersJson = layers ? JSON.stringify(layers) : undefined;
           ImageLayer,
           VectorTileLayer,
         } from "@types";
+        import type { LngLatLike } from "maplibre-gl";
         import { loadMapLayers } from "@lib/utils";
         class MapLibreScrollytellingMap extends HTMLElement {
           constructor() {
@@ -132,14 +141,51 @@ const layersJson = layers ? JSON.stringify(layers) : undefined;
                         loadMapLayers(map, layers, true);
                       }
 
-                      // Update the MapLibre map
-                      map.flyTo({
-                        center: center as maplibregl.LngLatLike,
+                      // Update map position via animation type if specified
+                      map[
+                        (entry.target.getAttribute("data-map-animation") as
+                          | "flyTo"
+                          | "easeTo"
+                          | "jumpTo") ?? "flyTo"
+                      ]({
+                        center: center as LngLatLike,
                         zoom: zoom ? parseFloat(zoom) : undefined,
                         pitch: pitch ? parseFloat(pitch) : undefined,
                         bearing: bearing ? parseFloat(bearing) : undefined,
                         essential: true,
                       });
+
+                      
+
+const rotateAnimation =
+  entry.target.getAttribute("data-map-rotate-animation") === "true";
+
+console.log(rotateAnimation);
+
+if (rotateAnimation) {
+  if (!isRotating) {
+    // Start the rotation if it's not already running
+    isRotating = true;
+
+    const rotate = () => {
+      if (isRotating) {
+        map.rotateTo(map.getBearing() + 180, {
+          duration: 30000,
+          easing: (t) => t,
+        });
+      }
+    };
+
+    map.on("moveend", rotate);
+    rotate(); // Trigger the first rotation immediately
+  }
+} else {
+  if (isRotating) {
+    // Stop the rotation when leaving a rotating block
+    isRotating = false;
+    map.off("moveend"); // Remove the `moveend` event listener
+  }
+}
                     } else {
                       if (!entry.target.getAttribute("data-persist")) {
                         // Remove the active class from the section
@@ -197,6 +243,10 @@ const layersJson = layers ? JSON.stringify(layers) : undefined;
           data-pitch={step.pitch}
           data-bearing={step.bearing}
           data-layers={JSON.stringify(step.layers)}
+          data-map-animation={step.mapAnimation}
+          data-map-rotate-animation={
+            step.rotateAnimation === true ? "true" : "false"
+          }
           class:list={[step.position ? step.position : "lefty", "step"]}
         >
           <div class="step-content">


### PR DESCRIPTION
adds optional `mapAnimation` and `rotateAnimation` flags for scrollytelling steps, following the logic used by mapbox for the same + readme documentation