### PR TITLE
Layer handling btw chapters

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -139,6 +139,9 @@ export function loadMapLayers(
                   },
                 });
               }
+              if (map.getLayer(layer.id)) {
+                updateLayer(map, layer);
+              }
             });
         } else if (layer["data-type"] === "raster") {
           // Add source if it doesn't exist
@@ -294,6 +297,29 @@ export function loadMapLayers(
         }
       }
     );
+  }
+}
+
+export function updateLayer(
+  map: maplibregl.Map,
+  layer: GeoJSONFeatureLayer | RasterLayer | ImageLayer | VectorTileLayer
+) {
+  if (map && map.getSource(layer.id)) {
+    if ("paint" in layer) {
+      layer.paint
+        ? // @ts-expect-error expect partial paint defs
+          layer.paint.array.forEach((element) => {
+            map.setPaintProperty(layer.id, element.property, element.value);
+          })
+        : null;
+    }
+    if ("visibility" in layer) {
+      map.setLayoutProperty(
+        layer.id,
+        "visibility",
+        layer.visible ? "visible" : "none"
+      );
+    }
   }
 }
 

--- a/src/pages/_scrollytelling_steps.yaml
+++ b/src/pages/_scrollytelling_steps.yaml
@@ -29,6 +29,30 @@
       circle-color: '#826260'
       circle-opacity: 0.8
 
+- title: Section Title - Squirrels in Central Park but different
+  center: [-73.96778, 40.78376]
+  zoom: 14
+  pitch: 0
+  bearing: 20
+  description: Now we zoom in. A layer is added from a geojson  Layer paint properties are passed, and layers are set to turn off when you continue scrolling via the `persist:false` attribute.
+  
+  layers:
+  # id of layer
+  - id: 'squirrel-census'
+  # path to dataset 
+  # note anything uploaded in the public/data folder will be uploaded to your site at url/data/file.png
+    url: './data/squirrel20241021.geojson'
+  # type of symbol
+    type: 'circle'
+  # type of symbol
+    data-type: 'geojson'
+    layer-type: 'circle'
+    persist: true
+    paint:
+      circle-radius: 8
+      circle-color: '#000'
+      circle-opacity: 0.8
+
 - title: Polygon Layer
   # center: [-73.96778, 40.78376]
   center: [-74.00739, 40.67930]


### PR DESCRIPTION
Based on a comment in class, started looking at updating map style between chapters. I think the layer updating is fine, but realized it doesn't matter if the layers are removed between steps anyway, so pausing on the layer handling side until that part is squared away. 
- [ ] handle layers between chapters (a la `onChapterEnter` and `onChapterExit` in mapbox scrollytelling logic)
- [x] update layer `paint` and `visible` properties if layer already exists
- [ ] update basemap style between chapters- would need to add another argument to the map step to control the map, but could implement via `setStyle`: https://docs.mapbox.com/mapbox-gl-js/example/setstyle/